### PR TITLE
Expand dependency on silverstripe/framework to allow silverstripe v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "silverstripe-vendormodule",
     "require": {
         "php": ">=5.6.0",
-        "silverstripe/framework": "^4.0",
+        "silverstripe/framework": "^4.0 || ^5.0",
         "guzzlehttp/psr7": "^1.3 || ^2.0"
     },
     "license": "BSD-3-Clause",


### PR DESCRIPTION
Silverstripe v5 is only breaking in a few specific areas, and as far as I can tell, no code changes need to be made to this project for compatibility with SS5. It's working completely fine in my project as-is.