### PR TITLE
Minimum PHP version is now ^8.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ PSR-7 compliant, immutable adapter interfaces for SilverStripe HTTP classes.
 
 * `silverstripe/framework` ^6.0
 * `guzzlehttp/psr7`
-* PHP ^8.1
+* PHP ^8.3
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "PSR-7 compliant adapters for SilverStripe HTTP classes",
     "type": "silverstripe-vendormodule",
     "require": {
-        "php": "^8.1",
+        "php": "^8.3",
         "silverstripe/framework": "^6.0",
         "guzzlehttp/psr7": "^1.3 || ^2.0"
     },


### PR DESCRIPTION
SilverStripe 6 requires PHP 8.3